### PR TITLE
Creates new updated Implementation Schedule page in Guidance

### DIFF
--- a/en/how-to-publish/establish-publishing-policies.rst
+++ b/en/how-to-publish/establish-publishing-policies.rst
@@ -11,27 +11,6 @@ This information should be initially recorded on the 'Publishing Information' ta
 
 .. contents ::
 
-
-The Implementation Schedule
-===========================
-
-The purpose of the Implementation Schedule is to:
-
-- Document an organisation's publishing policies to provide context to its published data files
-- Provide the time line for when data for each field of the IATI Standard was / will be published (or not published if not applicable / possible etc.)
-- Enable others and the IATI Secretariat to confirm that an organisation is delivering on its publishing commitment.
-
-The Implementation Schedule (currently in MS Excel format) is a living document and should ideally be subject to the version control. It can be updated and added to at any time, to reflect changes or additions to the way an organisation is reporting. 
- 
-The drafting of the Implementation Schedule can be done in parallel with preparing data for publication and it should also be published along side the IATI data. Whilst the Implementation Schedule is not a mandatory document to create (unless of course there is a contractual requirement attached to funding to produce one), it is strongly recommended that it is used in order to aid the publisher in publishing their data. 
-
-The Implementation Schedule for NGOs / CSOs can be `downloaded <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template%20-%20ngo/Implementation%20Schedule%20TEMPLATE%20for%20NGOs%20Sept%202013.xlsx>`__
-
-If your organisation reports to the DAC then the Common Standard Implementation Schedule should be `downloaded <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template-commonstandard/Implementation-Schedule-for-the-common-standard-ENG.xls>`__
-
-
-
-
 What Will Be Your Activity Unit of Aid? 
 =======================================
 

--- a/en/implementation-schedule.rst
+++ b/en/implementation-schedule.rst
@@ -1,0 +1,36 @@
+The Implementation Schedule
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The purpose of the Implementation Schedule is to:
+
+- Document an organisation's publishing policies to provide context to its published data files
+- Provide the time line for when data for each field of the IATI Standard was / will be published (or not published if not applicable / possible etc.)
+- Enable others and the IATI Secretariat to confirm that an organisation is delivering on its publishing commitment.
+
+The Implementation Schedule (currently in MS Excel format) is a living document and should ideally be subject to the version control. It can be updated and added to at any time, to reflect changes or additions to the way an organisation is reporting. 
+ 
+The drafting of the Implementation Schedule can be done in parallel with preparing data for publication and it should also be published along side the IATI data. Whilst the Implementation Schedule is not a mandatory document to create (unless of course there is a contractual requirement attached to funding to produce one), it is strongly recommended that it is used in order to aid the publisher in publishing their data. 
+
+Common Standard Implementation Schedule
+---------------------------------------
+If your organisation reports to the DAC then the Common Standard Implementation Schedule should be used:
+
+* `xlsx format (Excel) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template-commonstandard/Implementation-Schedule-for-the-common-standard-ENG.xls>`__
+
+* `ods format (Open Document Format) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template-commonstandard/Implementation-Schedule-for-the-common-standard-ENG.ods>`__
+
+Implementation Schedule for NGOs / CSOs 
+---------------------------------------
+This version can be downloaded in:
+
+* `xlsx format (Excel) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template%20-%20ngo/Implementation%20Schedule%20TEMPLATE%20for%20NGOs%20Sept%202013.xlsx>`__
+
+* `ods format (Open Document Format) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template%20-%20ngo/Implementation%20Schedule%20TEMPLATE%20for%20NGOs%20Sept%202013.ods>`__
+
+DFI IFI Implementation Schedule
+-------------------------------
+This version can be downloaded in:
+
+* `xlsx format (Excel) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template%20-%20DFIs/Best%20practice%20for%20IATI%20reporting%20by%20DFI%20IFI%20Implementation%20Schedule.xls>`__
+
+* `ods format (Open Document Format) <https://github.com/IATI/IATI-Implementation-Schedule/raw/master/files/template%20-%20DFIs/Best%20practice%20for%20IATI%20reporting%20by%20DFI%20IFI%20Implementation%20Schedule.ods>`__


### PR DESCRIPTION
Adds DFI Implementation Schdule links, etc
Creates standalone IS page in Guidance - this should sit in Guidance, but outside of How to Publish section
