### PR TITLE
Remove CSV2IATI from 'select publishing tool' page

### DIFF
--- a/en/how-to-publish/select-publishing-tool.rst
+++ b/en/how-to-publish/select-publishing-tool.rst
@@ -12,21 +12,6 @@ Aidstream (http://www.aidstream.org) is an online data entry and management tool
 
 There is a whole series of instructional videos on using Aidstream. These can be found at `Aidstream On Youtube <https://www.youtube.com/channel/UCAVH1gcgJXElsj8ENC-bDQQ>`__
 
-
-
-CSV Converter 
-=============
-
-The CSV Converter tool (http://csv2iati.iatistandard.org/) enables relevant activity information to be pulled from across the organisation into a single CSV file. Data for each activity is stored in a single row in the CSV file with column headings mapping to IATI fields .
-
-Once the CSV file is completed, it is uploaded to the conversion tool and a mapping model is created. Column titles from the CSV file are mapped to IATI fields so that information is picked up from the correct place. Default values for some fields can also be set. Once the mapping exercise is completed, you simply click to convert the data and the tool creates an Activity file (no organisation file) for publishing..
-
-Specific guidance on the use of the CSV Converter can be found at http://csv2iati.iatistandard.org/docs/user_guide.html. Examples of an input CSV file are also available as part of the online guidance.
-
-It is also recommended that Publishers creating their Activity files via the CSV Converter should also use Aidstream in order to create their organisation files
-
-
-
  
 Bespoke (In House Applications)
 ===============================


### PR DESCRIPTION
CSV2IATI is being decommissioned, so the page about choosing a publishing tool should no longer point anybody towards it.