### PR TITLE
Fix typo so non-embedded codelists table renders

### DIFF
--- a/en/upgrades/nonembedded-codelist-changelog.rst
+++ b/en/upgrades/nonembedded-codelist-changelog.rst
@@ -342,7 +342,7 @@ Updates to other non-embedded codelists
      - Add new codes and modify some descriptions.
      - Bring the list up-to-date with those published by the OECD DAC.
      - See `Updates to various DAC CRS non-embedded codelists <https://discuss.iatistandard.org/t/approved-updates-to-the-fileformat-codelist/903>`__
-    * - 3rd July 2017
+   * - 3rd July 2017
      - :doc:`FinanceType-category </codelists/FinanceType-category>`
      - Add new codes, modify some descriptions, add some French descriptions and mark some codes as withdrawn.
      - Bring the list up-to-date with those published by the OECD DAC.


### PR DESCRIPTION
I clicked the second link on [this IATI discuss post](https://discuss.iatistandard.org/t/update-on-the-roadmaps-for-iati-technical-team-products-august-december-2017/993) and noticed a bit chunk of the changelog was missing.

This PR fixes a typo to get [this (missing) table](http://iatistandard.org/202/upgrades/nonembedded-codelist-changelog/#updates-to-other-non-embedded-codelists) rendering:

![screen shot 2017-08-17 at 13 39 32](https://user-images.githubusercontent.com/464193/29412647-927b3efa-8351-11e7-9565-2934aefcf6eb.png)