### PR TITLE
Update nonembedded-codelist-changelog.rst

### DIFF
--- a/en/upgrades/nonembedded-codelist-changelog.rst
+++ b/en/upgrades/nonembedded-codelist-changelog.rst
@@ -330,7 +330,12 @@ Updates to other non-embedded codelists
      - Change description
      - Notes
      - Discussion
-   * - 3rd July 2017
+   * - 6th November 2017
+     - :doc:`Country </codelists/Country>`
+     - Mark a code as withdrawn
+     - Bring the list up to date with those published by ISO.
+     - See `Mark Netherland Antilles (AN) as withdrawn in Country codelist <https://discuss.iatistandard.org/t/approved-mark-netherland-antilles-an-as-withdrawn-in-country-codelist/1057>`__
+   * - 3rd July 2017
      - :doc:`AidType-category </codelists/AidType-category>`
      - Add French descriptions and add a URL.
      - Bring the list up-to-date with those published by the OECD DAC.


### PR DESCRIPTION
Mark Netherland Antilles (AN) as withdrawn in Country codelist.