### PR TITLE
Fix Codelist name capitalisation

### DIFF
--- a/en/upgrades/decimal-upgrade-to-2-03/2-03-changes.rst
+++ b/en/upgrades/decimal-upgrade-to-2-03/2-03-changes.rst
@@ -96,7 +96,7 @@ Alongside 2.03, the following codelists have moved from Embedded to Non-Embedded
 
 -	:doc:`/codelists/ActivityScope`
 -	:doc:`/codelists/BudgetIdentifier`
--	:doc:`/codelists/BudgetIdentifierSector-Category`
+-	:doc:`/codelists/BudgetIdentifierSector-category`
 -	:doc:`/codelists/BudgetIdentifierSector`
 -	:doc:`/codelists/BudgetIdentifierVocabulary`
 -	:doc:`/codelists/CRSAddOtherFlags`
@@ -104,7 +104,7 @@ Alongside 2.03, the following codelists have moved from Embedded to Non-Embedded
 -	:doc:`/codelists/ContactType`
 -	:doc:`/codelists/DescriptionType`
 -	:doc:`/codelists/DisbursementChannel`
--	:doc:`/codelists/DocumentCategory-Category`
+-	:doc:`/codelists/DocumentCategory-category`
 -	:doc:`/codelists/GeographicExactness`
 -	:doc:`/codelists/GeographicLocationClass`
 -	:doc:`/codelists/GeographicLocationReach`


### PR DESCRIPTION
Change capitalisation of Codelist names.

The generation process is very case-sensitive. This changes the sensitivity to be as required.