### PR TITLE
Fix copypaste error in 2.02 Upgrade info.

### DIFF
--- a/en/upgrades/decimal-upgrade-to-2-02.rst
+++ b/en/upgrades/decimal-upgrade-to-2-02.rst
@@ -8,8 +8,7 @@ Decimal Upgrade to 2.02
    decimal-upgrade-to-2-02/*
 
 
-The third decimal upgrade of the IATI standard took place
-during the autumn/winter of 2015.
+The 2.02 decimal upgrade of the IATI standard took place during the autumn/winter of 2015.
 
 Version 2.02 was released on Monday 7 December 2015.
 


### PR DESCRIPTION
1.04 was the 3rd Decimal Upgrade. 2.02 was the 5th Decimal Upgrade.
This commit removes a statement about how many upgrades there have been.