### PR TITLE
Adding previous-versions as subpage in sidemenu

### DIFF
--- a/en/upgrades.rst
+++ b/en/upgrades.rst
@@ -5,7 +5,6 @@ Upgrades
 	 :hidden:
 
 	 upgrades/all-versions
-	 upgrades/all/versions/previous-process
 	 upgrades/nonembedded-codelist-changelog
 	 upgrades/decimal-upgrade-to-2-03
 	 upgrades/decimal-upgrade-to-2-02

--- a/en/upgrades/all-versions.rst
+++ b/en/upgrades/all-versions.rst
@@ -1,6 +1,12 @@
 All Versions
 ============
 
+.. toctree::
+   :hidden:
+   :glob:
+
+   all-versions/*
+
 Links to all versions IATI Standard documentation are available below. This
 includes versions of the documentation, schemas and codelists.
 


### PR DESCRIPTION
This would add the previous-versions page to the left side-menu, and also include the same side menu on the previous-versions page. 