### PR TITLE
Get non-embedded codelist changelog rendering again

### DIFF
--- a/en/upgrades/nonembedded-codelist-changelog.rst
+++ b/en/upgrades/nonembedded-codelist-changelog.rst
@@ -346,7 +346,7 @@ Updates to other non-embedded codelists
      - :doc:`Currency </codelists/Currency>`
      - Updated the Currency codelist to reflect changes to the ISO Currency codelist as of 6th December 2018.
      - Added status 'withdrawn' to the VEF - Bolivar currency and added new code VES - Bolivar Soberano, as per the ISO currency codelist.
-     - See the discussion `here <https://discuss.iatistandard.org/t/update-currency-codelist-to-show-ves-bolivar-soberano/1591>`__      
+     - See the discussion `here <https://discuss.iatistandard.org/t/update-currency-codelist-to-show-ves-bolivar-soberano/1591>`__
   * - 20th August 2018
      - :doc:`Currency </codelists/Currency>`
      - Added status 'withdrawn' to the USS - US Dollar (Same Day) currency, as per the ISO currency codelist.

--- a/en/upgrades/nonembedded-codelist-changelog.rst
+++ b/en/upgrades/nonembedded-codelist-changelog.rst
@@ -347,7 +347,7 @@ Updates to other non-embedded codelists
      - Updated the Currency codelist to reflect changes to the ISO Currency codelist as of 6th December 2018.
      - Added status 'withdrawn' to the VEF - Bolivar currency and added new code VES - Bolivar Soberano, as per the ISO currency codelist.
      - See the discussion `here <https://discuss.iatistandard.org/t/update-currency-codelist-to-show-ves-bolivar-soberano/1591>`__
-  * - 20th August 2018
+   * - 20th August 2018
      - :doc:`Currency </codelists/Currency>`
      - Added status 'withdrawn' to the USS - US Dollar (Same Day) currency, as per the ISO currency codelist.
      - Change was put on hold whilst discussing which codes should be marked as 'withdrawn'.


### PR DESCRIPTION
References https://github.com/IATI/IATI-Guidance/pull/331/files#r239454780

Whitespace changes to fix markdown syntax error.

Here’s the rendered table on this branch, courtesy of github:
https://github.com/andylolz/IATI-Guidance/blob/fix-markdown-error/en/upgrades/nonembedded-codelist-changelog.rst#updates-to-other-non-embedded-codelists

Note that a similar issue was fixed back in #262. Github very helpfully will render markdown for you, so it’s always possible to view the branch on github and check whether something like this is broken, prior to merging.