### PR TITLE
Mark version 1.x as deprecated

### DIFF
--- a/en/upgrades/all-versions.rst
+++ b/en/upgrades/all-versions.rst
@@ -15,49 +15,48 @@ Current live versions
 
 The current live versions are:
 
-- 2.03: http://iatistandard.org/203/
+- 2.03 (latest) https://iatistandard.org/203/
 
-- 2.02: http://iatistandard.org/202/
+- 2.02: https://iatistandard.org/202/
 
-- 2.01: http://iatistandard.org/201/
+- 2.01: https://iatistandard.org/201/
 
-- 1.05: http://iatistandard.org/105/
-
-
-Previous Versions
+Deprecated versions
 -----------------
-Previous versions of the IATI Standard are available.  Publishers are able to release data to these versions:
+These versions of the IATI Standard are deprecated and no longer supported for publishing. Data is still available for consultation.
 
-- 1.04: http://iatistandard.org/104/
+- 1.05: https://iatistandard.org/105/
 
-- 1.03: http://iatistandard.org/103/
+- 1.04: https://iatistandard.org/104/
 
-- 1.02: http://iatistandard.org/102/
+- 1.03: https://iatistandard.org/103/
 
-- 1.01: http://iatistandard.org/101/
+- 1.02: https://iatistandard.org/102/
+
+- 1.01: https://iatistandard.org/101/
 
 
 Changelogs
 ----------
 Changelogs are available for all versions of the IATI Standard
 
-- 2.03: http://iatistandard.org/upgrades/decimal-upgrade-to-2-03/2-03-changes/
+- 2.03: https://iatistandard.org/upgrades/decimal-upgrade-to-2-03/2-03-changes/
 
-- 2.02: http://iatistandard.org/upgrades/decimal-upgrade-to-2-02/2-02-changes/
+- 2.02: https://iatistandard.org/upgrades/decimal-upgrade-to-2-02/2-02-changes/
 
-- 2.01: http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/
+- 2.01: https://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/
 
-- 1.05: http://iatistandard.org/upgrades/decimal-upgrade-to-1-05/1-05-changes/
+- 1.05: https://iatistandard.org/upgrades/decimal-upgrade-to-1-05/1-05-changes/
 
-- 1.04: http://iatistandard.org/upgrades/decimal-upgrade-to-1-04/1-04-changes/
+- 1.04: https://iatistandard.org/upgrades/decimal-upgrade-to-1-04/1-04-changes/
 
-- 1.03: http://iatistandard.org/upgrades/decimal-upgrade-to-1-03/1-03-changes/
+- 1.03: https://iatistandard.org/upgrades/decimal-upgrade-to-1-03/1-03-changes/
 
-- 1.02: http://iatistandard.org/upgrades/decimal-upgrade-to-1-02/1-02-changes/
+- 1.02: https://iatistandard.org/upgrades/decimal-upgrade-to-1-02/1-02-changes/
 
-A technical changelog is also available alongside the IATI schema: http://iatistandard.org/schema/
+A technical changelog is also available alongside the IATI schema: https://iatistandard.org/schema/
 
 Upgrade Processes
 ----------
-Version 2.03 and prior upgrades followed the `previous upgrade process <http://iatistandard.org/upgrades/all-versions/previous-process>`__.
+Version 2.03 and prior upgrades followed the `previous upgrade process <https://iatistandard.org/upgrades/all-versions/previous-process>`__.
 


### PR DESCRIPTION
Also changes all urls to https